### PR TITLE
add toggle hide option

### DIFF
--- a/src/js/multi-select-tag.js
+++ b/src/js/multi-select-tag.js
@@ -56,13 +56,7 @@ function MultiSelectTag (el, customs = {shadow: false, rounded:true, toggleHide:
         })
         
         window.addEventListener('click', (e) => {   
-            if (!customSelectContainer.contains(e.target)){
-                if (customs.toggleHide)
-                {
-                    enableItemSelection()
-                    return
-                }
-
+            if (!wrapper.contains(e.target) && !drawer.contains(e.target)){
                 drawer.classList.add('hidden')
             }
         });

--- a/src/js/multi-select-tag.js
+++ b/src/js/multi-select-tag.js
@@ -2,7 +2,7 @@
 // Email: habibmhamadi@gmail.com
 
 
-function MultiSelectTag (el, customs = {shadow: false, rounded:true}) {
+function MultiSelectTag (el, customs = {shadow: false, rounded:true, toggleHide: false}) {
     var element = null
     var options = null
     var customSelectContainer = null
@@ -31,6 +31,11 @@ function MultiSelectTag (el, customs = {shadow: false, rounded:true}) {
                 enableItemSelection()
                 drawer.classList.remove('hidden')
                 input.focus()
+            } else {
+                if (customs.toggleHide)
+                {
+                    drawer.classList.add('hidden')
+                }
             }
         })
 
@@ -52,6 +57,12 @@ function MultiSelectTag (el, customs = {shadow: false, rounded:true}) {
         
         window.addEventListener('click', (e) => {   
             if (!customSelectContainer.contains(e.target)){
+                if (customs.toggleHide)
+                {
+                    enableItemSelection()
+                    return
+                }
+
                 drawer.classList.add('hidden')
             }
         });


### PR DESCRIPTION
# Toggle Hiding Options Container
Added a new property to the customs object for the `MultiSelectTag()` function.
This property controls how the options hiding is controlled.

## When `toggleHide` is False
The list container will remain visible until an option is selected and the container will be hidden. 

```js
new MultiSelectTag('countries', {
    toggleHide: false    // default is false
})
```

## When `toggleHide` is True
The list container will remain visible until the drop down array is clicked again. The container will remain visible even if an option is selected.

```js
new MultiSelectTag('countries', {
    toggleHide: true    // default is false
})
```